### PR TITLE
Bug: fix the placeholder image url if missing

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,6 +20,8 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
+  const imgSrc = item.image !== "" ? item.image : "placeholder.png";
+
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {
@@ -36,7 +38,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image !== "" ? item.image : "placeholder.png"}
+        src={imgSrc}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,8 +20,6 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
-  const imgSrc = item.image !== "" ? item.image : "placeholder.png";
-
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {
@@ -38,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={imgSrc}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image !== "" ? item.image : "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

When no image is inputed by the user, the API returns `image: ""`. In order to place the placeholder images, in front end user `image: placeholder.png` if `image` is `""`. 

Closes #2.

# Behaviour  

![image](https://user-images.githubusercontent.com/22895284/179775230-40477e35-fcbd-4c11-a0a2-c3acd42fbfae.png)

